### PR TITLE
Create get_channel_size helper function (#1)

### DIFF
--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -1,0 +1,30 @@
+import unittest
+
+from pggan.helper import get_channel_size
+
+
+class TestHelper(unittest.TestCase):
+
+    def test_get_channel_size_of_conv_blocks(self):
+        channel_512_to_16 = [(512, 512),
+                             (512, 512),
+                             (512, 512),
+                             (512, 512),
+                             (512, 256),
+                             (256, 128),
+                             (128, 64),
+                             (64, 32),
+                             (32, 16),
+                             (16, 3)]
+
+        channels_256_to_32 = [(256, 256),
+                              (256, 256),
+                              (256, 256),
+                              (256, 256),
+                              (256, 128),
+                              (128, 64),
+                              (64, 32),
+                              (32, 3)]
+
+        self.assertEqual(get_channel_size(512, 16), channel_512_to_16)
+        self.assertEqual(get_channel_size(256, 32), channels_256_to_32)


### PR DESCRIPTION
- 생성자와 구분자의 네트워크 대칭 구조를 자동으로 맞추기 위한 함수
- 컨볼루션 레이어의 최대값과 최소값을 기준으로 각 컨볼루션 레이어의 커널 갯수를 반환하여 필요한 컨볼루션 레이어 갯수와 채널 사이즈를 얻을 수 있음